### PR TITLE
Fix celery import error

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,3 +5,4 @@ celery==4.4.7
 pika==1.2.0
 skipper-lib==1.1.7
 requests==2.25.1
+importlib-metadata==4.8.3


### PR DESCRIPTION
Was getting `ImportError: cannot import name 'Celery' from 'celery'` from the api container.